### PR TITLE
Add short format option

### DIFF
--- a/lib/read_my_time/reader.rb
+++ b/lib/read_my_time/reader.rb
@@ -8,6 +8,7 @@ module ReadMyTime
 
       # options by default
       opts[:skip_seconds] = false if opts[:skip_seconds].nil?
+      opts[:short_format] = false if opts[:short_format].nil?
 
       unit_time_dividers.each_with_object([]) do |(unit_time, divider), s|
 
@@ -16,6 +17,7 @@ module ReadMyTime
 
           if rest.nonzero? && !(unit_time == :seconds && opts[:skip_seconds])
             word = I18n.t(unit_time.to_s, count: rest, scope: locale_prefix)
+            word = (opts[:short_format] ? word[0] : word)
             s.unshift("#{rest} #{word}")
           end
         end

--- a/test/test_read_my_time.rb
+++ b/test/test_read_my_time.rb
@@ -20,6 +20,10 @@ class TestReadMyTime < MiniTest::Test
     assert_equal('', 10.seconds_in_words(skip_seconds: true))
   end
 
+  def test_return_seconds_using_short_format
+    assert_equal('10 s', 10.seconds_in_words(short_format: true))
+  end
+
   def test_handle_float_values
     assert_equal('10 seconds', 10.1.seconds_in_words)
   end
@@ -38,6 +42,10 @@ class TestReadMyTime < MiniTest::Test
 
   def test_return_word_days
     assert_equal('1 day 1 hour 1 minute 40 seconds', (1.day + 1.hour + 1.minute + 40).seconds_in_words)
+  end
+
+  def test_return_word_days_using_short_format
+    assert_equal('1 d 1 h 1 m 40 s', (1.day + 1.hour + 1.minute + 40).seconds_in_words(short_format: true))
   end
 
   # skip show 0 values


### PR DESCRIPTION
Add a short format option.

```ruby
10.seconds_in_words(short_format: true)
# => 10 s
```

```ruby
(1.day + 1.hour + 1.minute + 40).seconds_in_words(short_format: true)
# => 1 d 1 h 1 m 40 s
```